### PR TITLE
Fix type annotatons

### DIFF
--- a/tokenize_rt.py
+++ b/tokenize_rt.py
@@ -26,7 +26,7 @@ class Offset(collections.namedtuple('Offset', ('line', 'utf8_byte_offset'))):
     __slots__ = ()
 
     def __new__(cls, line=None, utf8_byte_offset=None):
-        # type: (Optional[int], Optional[int]) -> None
+        # type: (Optional[int], Optional[int]) -> 'Offset'
         return super(Offset, cls).__new__(cls, line, utf8_byte_offset)
 
 
@@ -38,7 +38,7 @@ class Token(
     __slots__ = ()
 
     def __new__(cls, name, src, line=None, utf8_byte_offset=None):
-        # type: (str, str, Optional[int], Optional[int]) -> None
+        # type: (str, str, Optional[int], Optional[int]) -> 'Token'
         return super(Token, cls).__new__(
             cls, name, src, line, utf8_byte_offset,
         )


### PR DESCRIPTION
This fixes a few lint errors I saw in pyupgrade (only flagged by IntelliJ)

![image](https://user-images.githubusercontent.com/252209/60769908-5c4a5700-a0a3-11e9-8296-d28c323aeec6.png)

![image](https://user-images.githubusercontent.com/252209/60769912-62d8ce80-a0a3-11e9-94a2-5afeb9fd2b84.png)

~https://user-images.githubusercontent.com/252209/60769913-666c5580-a0a3-11e9-98bd-a392743fd381.png~ will follow up about that one separately
