### PR TITLE
Drop universal wheel declaration

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -28,9 +28,6 @@ python_requires = >=3.6.1
 console_scripts =
     tokenize-rt = tokenize_rt:main
 
-[bdist_wheel]
-universal = True
-
 [coverage:run]
 plugins = covdefaults
 


### PR DESCRIPTION
This project supports Python 3 only now so the wheel should not be marked as universally supporting Pythons 2 and 3.