### PR TITLE
fix tags trigger for github actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,7 +3,7 @@ name: main
 on:
   push:
     branches: [main, test-me-*]
-    tags:
+    tags: '*'
   pull_request:
 
 jobs:


### PR DESCRIPTION
the old syntax worked for azure pipelines but not GHA

Committed via https://github.com/asottile/all-repos